### PR TITLE
Save and Publish Annotations

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,6 +55,7 @@ jobs:
         environment:
           GOPATH: /go
           ANNOTATIONS_PUBLISH_ENDPOINT: https://httpbin.org/post
+          ANNOTATIONS_SAVE_ENDPOINT: https://httpbin.org/put?%v
           ANNOTATIONS_PUBLISH_AUTH: fake-user:fake-pass
     steps:
       - checkout

--- a/annotations/publisher.go
+++ b/annotations/publisher.go
@@ -28,8 +28,8 @@ type uppPublisher struct {
 }
 
 // NewPublisher returns a new Publisher instance
-func NewPublisher(originSystemID string, publishEndpoint string, publishAuth string, gtgEndpoint string) Publisher {
-	return &uppPublisher{client: &http.Client{}, originSystemID: originSystemID, publishEndpoint: publishEndpoint, publishAuth: publishAuth, gtgEndpoint: gtgEndpoint}
+func NewPublisher(client *http.Client, originSystemID string, publishEndpoint string, publishAuth string, gtgEndpoint string) Publisher {
+	return &uppPublisher{client: client, originSystemID: originSystemID, publishEndpoint: publishEndpoint, publishAuth: publishAuth, gtgEndpoint: gtgEndpoint}
 }
 
 // Publish sends the annotations to UPP via the configured publishEndpoint. Requests contain X-Origin-System-Id and X-Request-Id and a User-Agent as provided.

--- a/annotations/publisher_test.go
+++ b/annotations/publisher_test.go
@@ -14,7 +14,7 @@ import (
 
 func TestPublish(t *testing.T) {
 	uuid := uuid.New()
-	server := startMockServer(t, uuid, true, true)
+	server := startMockPublishServer(t, uuid, true, true)
 	defer server.Close()
 
 	publisher := NewPublisher("originSystemID", server.URL+"/notify", "user:pass", server.URL+"/__gtg")
@@ -50,7 +50,7 @@ func TestPublishRequestFailsServerUnavailable(t *testing.T) {
 
 func TestPublishRequestUnsuccessful(t *testing.T) {
 	uuid := uuid.New()
-	server := startMockServer(t, uuid, false, true)
+	server := startMockPublishServer(t, uuid, false, true)
 	defer server.Close()
 
 	publisher := NewPublisher("originSystemID", server.URL+"/notify", "user:pass", server.URL+"/__gtg")
@@ -81,7 +81,7 @@ func TestPublisherAuthIsInvalid(t *testing.T) {
 
 func TestPublisherAuthenticationFails(t *testing.T) {
 	uuid := uuid.New()
-	server := startMockServer(t, uuid, false, true)
+	server := startMockPublishServer(t, uuid, false, true)
 	defer server.Close()
 
 	publisher := NewPublisher("originSystemID", server.URL+"/notify", "user:should-fail", server.URL+"/__gtg")
@@ -92,7 +92,7 @@ func TestPublisherAuthenticationFails(t *testing.T) {
 }
 
 func TestPublisherGTG(t *testing.T) {
-	server := startMockServer(t, "", true, true)
+	server := startMockPublishServer(t, "", true, true)
 	defer server.Close()
 
 	publisher := NewPublisher("originSystemID", "publishEndpoint", "user:pass", server.URL+"/__gtg")
@@ -101,7 +101,7 @@ func TestPublisherGTG(t *testing.T) {
 }
 
 func TestPublisherGTGFails(t *testing.T) {
-	server := startMockServer(t, "", true, false)
+	server := startMockPublishServer(t, "", true, false)
 	defer server.Close()
 
 	publisher := NewPublisher("originSystemID", "publishEndpoint", "user:pass", server.URL+"/__gtg")
@@ -121,7 +121,7 @@ func TestPublisherGTGInvalidURL(t *testing.T) {
 	assert.EqualError(t, err, "parse :: missing protocol scheme")
 }
 
-func startMockServer(t *testing.T, uuid string, publishOk bool, gtgOk bool) *httptest.Server {
+func startMockPublishServer(t *testing.T, uuid string, publishOk bool, gtgOk bool) *httptest.Server {
 	r := vestigo.NewRouter()
 	r.Get("/__gtg", func(w http.ResponseWriter, r *http.Request) {
 		userAgent := r.Header.Get("User-Agent")

--- a/annotations/writer.go
+++ b/annotations/writer.go
@@ -31,7 +31,8 @@ func (p *pacWriter) Write(uuid string, tid string, body map[string]interface{}) 
 		return nil, err
 	}
 
-	req, err := http.NewRequest("PUT", fmt.Sprintf(p.saveEndpoint, uuid), bytes.NewReader(bodyJSON))
+	uri := fmt.Sprintf(p.saveEndpoint, uuid)
+	req, err := http.NewRequest("PUT", uri, bytes.NewReader(bodyJSON))
 	if err != nil {
 		return nil, err
 	}
@@ -48,7 +49,7 @@ func (p *pacWriter) Write(uuid string, tid string, body map[string]interface{}) 
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("Save to %v returned a %v status code", p.saveEndpoint, resp.StatusCode)
+		return nil, fmt.Errorf("Save to %v returned a %v status code", uri, resp.StatusCode)
 	}
 
 	dec := json.NewDecoder(resp.Body)

--- a/annotations/writer.go
+++ b/annotations/writer.go
@@ -1,0 +1,87 @@
+package annotations
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+)
+
+// Writer saves annotations via the configured PUT endpoint
+type Writer interface {
+	Write(uuid string, tid string, body map[string]interface{}) (map[string]interface{}, error)
+	GTG() error
+	Endpoint() string
+}
+
+type pacWriter struct {
+	client          *http.Client
+	saveEndpoint    string
+	saveGTGEndpoint string
+}
+
+// NewWriter returns a new PAC annotations writer
+func NewWriter(client *http.Client, saveEndpoint string, saveGTGEndpoint string) Writer {
+	return &pacWriter{client: client, saveEndpoint: saveEndpoint, saveGTGEndpoint: saveGTGEndpoint}
+}
+
+func (p *pacWriter) Write(uuid string, tid string, body map[string]interface{}) (map[string]interface{}, error) {
+	bodyJSON, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("PUT", fmt.Sprintf(p.saveEndpoint, uuid), bytes.NewReader(bodyJSON))
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("User-Agent", "PAC annotations-publisher")
+	req.Header.Add("X-Request-Id", tid)
+	req.Header.Add("Content-Type", "application/json")
+
+	resp, err := p.client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("Save to %v returned a %v status code", p.saveEndpoint, resp.StatusCode)
+	}
+
+	dec := json.NewDecoder(resp.Body)
+	respBody := make(map[string]interface{})
+	err = dec.Decode(&respBody)
+	if err != nil {
+		return nil, err
+	}
+
+	return respBody, nil
+}
+
+func (p *pacWriter) GTG() error {
+	req, err := http.NewRequest("GET", p.saveGTGEndpoint, nil)
+	if err != nil {
+		return err
+	}
+
+	req.Header.Add("User-Agent", "PAC annotations-publisher")
+	resp, err := p.client.Do(req)
+	if err != nil {
+		return err
+	}
+
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("GTG %v returned a %v status code", p.saveGTGEndpoint, resp.StatusCode)
+	}
+
+	return nil
+}
+
+func (p *pacWriter) Endpoint() string {
+	return p.saveEndpoint
+}

--- a/annotations/writer_test.go
+++ b/annotations/writer_test.go
@@ -1,0 +1,166 @@
+package annotations
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/husobee/vestigo"
+	"github.com/pborman/uuid"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestWrite(t *testing.T) {
+	uuid := uuid.New()
+	server := startMockWriteServer(t, uuid, true, true, false)
+	defer server.Close()
+
+	writer := NewWriter(http.DefaultClient, server.URL+"/drafts/content/%v/annotations", server.URL+"/__gtg")
+
+	body := make(map[string]interface{})
+	resp, err := writer.Write(uuid, "tid_"+uuid, body)
+	assert.NoError(t, err)
+	assert.Len(t, resp, 1)
+	assert.Equal(t, resp["worked"], "yep", "Response should match what the mock server writes back")
+}
+
+func TestJSONMarshalFails(t *testing.T) {
+	writer := NewWriter(http.DefaultClient, "/drafts/content/%v/annotations", "/__gtg")
+
+	body := make(map[string]interface{})
+	body["test"] = func() {}
+
+	_, err := writer.Write("uuid", "tid", body)
+	assert.EqualError(t, err, "json: unsupported type: func()")
+}
+
+func TestWriteRequestFails(t *testing.T) {
+	writer := NewWriter(http.DefaultClient, ":#%v", "/__gtg")
+
+	body := make(map[string]interface{})
+
+	_, err := writer.Write("", "tid", body)
+	assert.EqualError(t, err, "parse :: missing protocol scheme")
+}
+
+func TestWriteRequestURLInvalid(t *testing.T) {
+	writer := NewWriter(http.DefaultClient, "#:%v", "/__gtg")
+
+	body := make(map[string]interface{})
+
+	_, err := writer.Write("", "tid", body)
+	assert.EqualError(t, err, "Put #:: unsupported protocol scheme \"\"")
+}
+
+func TestWriteResponseFails(t *testing.T) {
+	uuid := uuid.New()
+	server := startMockWriteServer(t, uuid, false, true, false)
+	defer server.Close()
+
+	writer := NewWriter(http.DefaultClient, server.URL+"/drafts/content/%v/annotations", server.URL+"/__gtg")
+
+	body := make(map[string]interface{})
+	_, err := writer.Write(uuid, "tid_"+uuid, body)
+	assert.EqualError(t, err, fmt.Sprintf("Save to %v/drafts/content/%%v/annotations returned a 503 status code", server.URL))
+}
+
+func TestWriteResponseInvalidJSON(t *testing.T) {
+	uuid := uuid.New()
+	server := startMockWriteServer(t, uuid, true, true, true)
+	defer server.Close()
+
+	writer := NewWriter(http.DefaultClient, server.URL+"/drafts/content/%v/annotations", server.URL+"/__gtg")
+
+	body := make(map[string]interface{})
+	_, err := writer.Write(uuid, "tid_"+uuid, body)
+	assert.EqualError(t, err, "invalid character 'd' looking for beginning of object key string")
+}
+
+func TestWriteGTG(t *testing.T) {
+	server := startMockWriteServer(t, "uuid", true, true, false)
+	defer server.Close()
+
+	writer := NewWriter(http.DefaultClient, server.URL+"/drafts/content/%v/annotations", server.URL+"/__gtg")
+
+	err := writer.GTG()
+	assert.NoError(t, err)
+}
+
+func TestWriteGTGNon200Status(t *testing.T) {
+	server := startMockWriteServer(t, "uuid", true, false, false)
+	defer server.Close()
+
+	writer := NewWriter(http.DefaultClient, server.URL+"/drafts/content/%v/annotations", server.URL+"/__gtg")
+
+	err := writer.GTG()
+	assert.EqualError(t, err, fmt.Sprintf("GTG %v/__gtg returned a 503 status code", server.URL))
+}
+
+func TestWriteGTGRequestFails(t *testing.T) {
+	writer := NewWriter(http.DefaultClient, "/drafts/content/%v/annotations", "#:")
+
+	err := writer.GTG()
+	assert.EqualError(t, err, "Get #:: unsupported protocol scheme \"\"")
+}
+
+func TestWriteGTGInvalidURL(t *testing.T) {
+	writer := NewWriter(http.DefaultClient, "/drafts/content/%v/annotations", ":#")
+
+	err := writer.GTG()
+	assert.EqualError(t, err, "parse :: missing protocol scheme")
+}
+
+func TestWriterEndpoint(t *testing.T) {
+	writer := NewWriter(http.DefaultClient, "/drafts/content/%v/annotations", ":#")
+
+	actual := writer.Endpoint()
+	assert.Equal(t, "/drafts/content/%v/annotations", actual)
+}
+
+func startMockWriteServer(t *testing.T, uuid string, saveOk bool, gtgOk bool, incorrectResponseJSON bool) *httptest.Server {
+	r := vestigo.NewRouter()
+	r.Get("/__gtg", func(w http.ResponseWriter, r *http.Request) {
+		userAgent := r.Header.Get("User-Agent")
+		assert.Equal(t, "PAC annotations-publisher", userAgent)
+
+		if !gtgOk {
+			w.WriteHeader(http.StatusServiceUnavailable)
+		} else {
+			w.WriteHeader(http.StatusOK)
+		}
+	})
+
+	r.Put("/drafts/content/:uuid/annotations", func(w http.ResponseWriter, r *http.Request) {
+		reqUUID := vestigo.Param(r, "uuid")
+		assert.Equal(t, uuid, reqUUID, "Request path uuid should match the expected uuid")
+
+		userAgent := r.Header.Get("User-Agent")
+		assert.Equal(t, "PAC annotations-publisher", userAgent)
+
+		contentType := r.Header.Get("Content-Type")
+		assert.Equal(t, "application/json", contentType)
+
+		tid := r.Header.Get("X-Request-Id")
+		assert.Equal(t, "tid_"+uuid, tid)
+
+		dec := json.NewDecoder(r.Body)
+		data := make(map[string]interface{})
+		err := dec.Decode(&data)
+		assert.NoError(t, err)
+
+		if !saveOk {
+			w.WriteHeader(http.StatusServiceUnavailable)
+		} else {
+			w.WriteHeader(http.StatusOK)
+		}
+
+		if incorrectResponseJSON {
+			w.Write([]byte(`{didn't work}`))
+		} else {
+			w.Write([]byte(`{"worked":"yep"}`))
+		}
+	})
+	return httptest.NewServer(r)
+}

--- a/annotations/writer_test.go
+++ b/annotations/writer_test.go
@@ -63,7 +63,7 @@ func TestWriteResponseFails(t *testing.T) {
 
 	body := make(map[string]interface{})
 	_, err := writer.Write(uuid, "tid_"+uuid, body)
-	assert.EqualError(t, err, fmt.Sprintf("Save to %v/drafts/content/%%v/annotations returned a 503 status code", server.URL))
+	assert.EqualError(t, err, fmt.Sprintf("Save to %v/drafts/content/%v/annotations returned a 503 status code", server.URL, uuid))
 }
 
 func TestWriteResponseInvalidJSON(t *testing.T) {

--- a/api/api.yml
+++ b/api/api.yml
@@ -71,8 +71,13 @@ paths:
           examples:
             application/json:
               message: Please specify a valid uuid in the request
+        500:
+          description: An authentication failure occurred while attempting to publish to UPP. This requires a configuration change to the service, followed by a restart, and is therefore not a client error (401).
+          examples:
+            application/json:
+              message: Publish authentication is invalid
         503:
-          description: A failure occurred while attempting to publish to UPP. Please check the `/__health` endpoint and try again.
+          description: A failure occurred while attempting to publish to UPP, or while attempting to save to PAC. Please check the `/__health` endpoint and try again.
           examples:
             application/json:
               message: Failed to publish to UPP

--- a/main.go
+++ b/main.go
@@ -74,6 +74,18 @@ func main() {
 		EnvVar: "API_YML",
 	})
 
+	saveEndpoint := app.String(cli.StringOpt{
+		Name:   "annotations-save-endpoint",
+		Desc:   "Endpoint to save annotations to PAC",
+		EnvVar: "ANNOTATIONS_SAVE_ENDPOINT",
+	})
+
+	saveGTGEndpoint := app.String(cli.StringOpt{
+		Name:   "annotations-save-gtg-endpoint",
+		Desc:   "GTG Endpoint for the service which saves PAC annotations (usually draft-annotations-api)",
+		EnvVar: "ANNOTATIONS_SAVE_GTG_ENDPOINT",
+	})
+
 	log.SetLevel(log.InfoLevel)
 	log.Infof("[Startup] %v is starting", *appSystemCode)
 
@@ -81,6 +93,8 @@ func main() {
 		log.Infof("System code: %s, App Name: %s, Port: %s", *appSystemCode, *appName, *port)
 
 		publisher := annotations.NewPublisher(*originSystemID, *annotationsEndpoint, *annotationsAuth, *annotationsGTGEndpoint)
+		writer := annotations.NewWriter(client, saveEndpoint, saveGTGEndpoint)
+
 		healthService := health.NewHealthService(*appSystemCode, *appName, appDescription, publisher)
 
 		serveEndpoints(*port, apiYml, publisher, healthService)

--- a/main.go
+++ b/main.go
@@ -77,12 +77,14 @@ func main() {
 	saveEndpoint := app.String(cli.StringOpt{
 		Name:   "annotations-save-endpoint",
 		Desc:   "Endpoint to save annotations to PAC",
+		Value:  "http://draft-annotations-api:8080/drafts/content/%v/annotations",
 		EnvVar: "ANNOTATIONS_SAVE_ENDPOINT",
 	})
 
 	saveGTGEndpoint := app.String(cli.StringOpt{
 		Name:   "annotations-save-gtg-endpoint",
 		Desc:   "GTG Endpoint for the service which saves PAC annotations (usually draft-annotations-api)",
+		Value:  "http://draft-annotations-api:8080/__gtg",
 		EnvVar: "ANNOTATIONS_SAVE_GTG_ENDPOINT",
 	})
 

--- a/resources/publish.go
+++ b/resources/publish.go
@@ -32,7 +32,7 @@ func Publish(writer annotations.Writer, publisher annotations.Publisher) func(w 
 		txid := tid.GetTransactionIDFromRequest(r)
 		savedBody, err := writer.Write(uuid, txid, body)
 		if err != nil {
-			writeMsg(w, http.StatusInternalServerError, err.Error())
+			writeMsg(w, http.StatusServiceUnavailable, err.Error())
 			return
 		}
 

--- a/resources/publish_test.go
+++ b/resources/publish_test.go
@@ -68,7 +68,7 @@ func (p *publishResourceTestSuite) TestWriteFails() {
 
 	resp, err := marshal(w.Body)
 	require.NoError(p.T(), err)
-	assert.Equal(p.T(), http.StatusInternalServerError, w.Code)
+	assert.Equal(p.T(), http.StatusServiceUnavailable, w.Code)
 	assert.Equal(p.T(), "eek", resp["message"])
 }
 

--- a/resources/publish_test.go
+++ b/resources/publish_test.go
@@ -12,89 +12,118 @@ import (
 	"github.com/Financial-Times/annotations-publisher/annotations"
 	"github.com/husobee/vestigo"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
 )
 
-func TestPublish(t *testing.T) {
-	r := vestigo.NewRouter()
-	pub := &mockPublisher{nil}
+type publishResourceTestSuite struct {
+	suite.Suite
+	router            *vestigo.Router
+	mockPublisher     *mockPublisher
+	mockWriter        *mockWriter
+	expectedWriteBody map[string]interface{}
+}
 
-	r.Post("/drafts/content/:uuid/annotations/publish", Publish(pub))
+func (p *publishResourceTestSuite) SetupTest() {
+	p.mockPublisher = new(mockPublisher)
+	p.router = vestigo.NewRouter()
+	p.expectedWriteBody = make(map[string]interface{})
+	p.expectedWriteBody["inserted"] = "something"
+	p.mockWriter = &mockWriter{nil}
+
+	p.router.Post("/drafts/content/:uuid/annotations/publish", Publish(p.mockWriter, p.mockPublisher))
+}
+
+func (p *publishResourceTestSuite) TearDownTest() {
+	p.mockPublisher.AssertExpectations(p.T())
+}
+
+func TestPublishResourceSuite(t *testing.T) {
+	suite.Run(t, &publishResourceTestSuite{})
+}
+
+func (p *publishResourceTestSuite) TestPublishSucceeds() {
+	p.mockPublisher.On("Publish", "a-valid-uuid", "tid_1234", p.expectedWriteBody).Return(nil)
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("POST", "/drafts/content/a-valid-uuid/annotations/publish", strings.NewReader(`{}`))
+	req.Header.Add("X-Request-Id", "tid_1234")
+
+	p.router.ServeHTTP(w, req)
+
+	resp, err := marshal(w.Body)
+	require.NoError(p.T(), err)
+	assert.Equal(p.T(), http.StatusAccepted, w.Code)
+	assert.Equal(p.T(), "Publish accepted", resp["message"])
+}
+
+func (p *publishResourceTestSuite) TestWriteFails() {
+	p.mockWriter.writeErr = errors.New("eek")
 
 	w := httptest.NewRecorder()
 	req := httptest.NewRequest("POST", "/drafts/content/a-valid-uuid/annotations/publish", strings.NewReader(`{}`))
 
-	r.ServeHTTP(w, req)
+	p.router.ServeHTTP(w, req)
 
-	assert.Equal(t, http.StatusAccepted, w.Code)
+	resp, err := marshal(w.Body)
+	require.NoError(p.T(), err)
+	assert.Equal(p.T(), http.StatusInternalServerError, w.Code)
+	assert.Equal(p.T(), "eek", resp["message"])
 }
 
-func TestBodyNotJSON(t *testing.T) {
-	r := vestigo.NewRouter()
-	pub := &mockPublisher{nil}
-
-	r.Post("/drafts/content/:uuid/annotations/publish", Publish(pub))
-
+func (p *publishResourceTestSuite) TestBodyNotJSON() {
 	w := httptest.NewRecorder()
 	req := httptest.NewRequest("POST", "/drafts/content/a-valid-uuid/annotations/publish", strings.NewReader(`{\`))
 
-	r.ServeHTTP(w, req)
+	p.router.ServeHTTP(w, req)
 
 	resp, err := marshal(w.Body)
-	require.NoError(t, err)
-	assert.Equal(t, http.StatusBadRequest, w.Code)
-	assert.Equal(t, "Failed to process request json. Please provide a valid json request body", resp["message"])
+	require.NoError(p.T(), err)
+	assert.Equal(p.T(), http.StatusBadRequest, w.Code)
+	assert.Equal(p.T(), "Failed to process request json. Please provide a valid json request body", resp["message"])
 }
 
-func TestRequestHasNoUUID(t *testing.T) {
-	r := vestigo.NewRouter()
-	pub := &mockPublisher{nil}
-
-	r.Post("/drafts/content/:uuid/annotations/publish", Publish(pub))
-
+func (p *publishResourceTestSuite) TestRequestHasNoUUID() {
 	w := httptest.NewRecorder()
 	req := httptest.NewRequest("POST", "/drafts/content//annotations/publish", strings.NewReader(`{}`))
 
-	r.ServeHTTP(w, req)
+	p.router.ServeHTTP(w, req)
 
 	resp, err := marshal(w.Body)
-	require.NoError(t, err)
-	assert.Equal(t, http.StatusBadRequest, w.Code)
-	assert.Equal(t, "Please specify a valid uuid in the request", resp["message"])
+	require.NoError(p.T(), err)
+	assert.Equal(p.T(), http.StatusBadRequest, w.Code)
+	assert.Equal(p.T(), "Please specify a valid uuid in the request", resp["message"])
 }
 
-func TestPublishFailed(t *testing.T) {
-	r := vestigo.NewRouter()
-	pub := &mockPublisher{errors.New("eek")}
-
-	r.Post("/drafts/content/:uuid/annotations/publish", Publish(pub))
+func (p *publishResourceTestSuite) TestPublishFailed() {
+	p.mockPublisher.On("Publish", "a-valid-uuid", "tid_1234", p.expectedWriteBody).Return(errors.New("eek"))
 
 	w := httptest.NewRecorder()
 	req := httptest.NewRequest("POST", "/drafts/content/a-valid-uuid/annotations/publish", strings.NewReader(`{}`))
+	req.Header.Add("X-Request-Id", "tid_1234")
 
-	r.ServeHTTP(w, req)
+	p.router.ServeHTTP(w, req)
 
 	resp, err := marshal(w.Body)
-	require.NoError(t, err)
-	assert.Equal(t, http.StatusServiceUnavailable, w.Code)
-	assert.Equal(t, "eek", resp["message"])
+	require.NoError(p.T(), err)
+	assert.Equal(p.T(), http.StatusServiceUnavailable, w.Code)
+	assert.Equal(p.T(), "eek", resp["message"])
 }
 
-func TestPublishAuthenticationInvalid(t *testing.T) {
-	r := vestigo.NewRouter()
-	pub := &mockPublisher{annotations.ErrInvalidAuthentication}
-
-	r.Post("/drafts/content/:uuid/annotations/publish", Publish(pub))
+func (p *publishResourceTestSuite) TestPublishAuthenticationInvalid() {
+	p.mockPublisher.On("Publish", "a-valid-uuid", "tid_1234", p.expectedWriteBody).Return(annotations.ErrInvalidAuthentication)
 
 	w := httptest.NewRecorder()
 	req := httptest.NewRequest("POST", "/drafts/content/a-valid-uuid/annotations/publish", strings.NewReader(`{}`))
+	req.Header.Add("X-Request-Id", "tid_1234")
 
-	r.ServeHTTP(w, req)
+	p.router.ServeHTTP(w, req)
 
 	resp, err := marshal(w.Body)
-	require.NoError(t, err)
-	assert.Equal(t, http.StatusInternalServerError, w.Code)
-	assert.Equal(t, "Publish authentication is invalid", resp["message"])
+	require.NoError(p.T(), err)
+	assert.Equal(p.T(), http.StatusInternalServerError, w.Code)
+	assert.Equal(p.T(), annotations.ErrInvalidAuthentication.Error(), resp["message"])
 }
 
 func marshal(body *bytes.Buffer) (map[string]interface{}, error) {
@@ -105,17 +134,37 @@ func marshal(body *bytes.Buffer) (map[string]interface{}, error) {
 }
 
 type mockPublisher struct {
-	publishErr error
+	mock.Mock
 }
 
 func (m *mockPublisher) GTG() error {
-	return nil
+	args := m.Called()
+	return args.Error(0)
 }
 
 func (m *mockPublisher) Endpoint() string {
-	return ""
+	args := m.Called()
+	return args.String(0)
 }
 
 func (m *mockPublisher) Publish(uuid string, tid string, body map[string]interface{}) error {
-	return m.publishErr
+	args := m.Called(uuid, tid, body)
+	return args.Error(0)
+}
+
+type mockWriter struct {
+	writeErr error
+}
+
+func (m *mockWriter) GTG() error {
+	return nil
+}
+
+func (m *mockWriter) Endpoint() string {
+	return ""
+}
+
+func (m *mockWriter) Write(uuid string, tid string, body map[string]interface{}) (map[string]interface{}, error) {
+	body["inserted"] = "something"
+	return body, m.writeErr
 }

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -115,14 +115,32 @@
 			"versionExact": "v1.0.3"
 		},
 		{
+			"checksumSHA1": "K0crHygPTP42i1nLKWphSlvOQJw=",
+			"path": "github.com/stretchr/objx",
+			"revision": "1a9d0bb9f541897e62256577b352fdbc1fb4fd94",
+			"revisionTime": "2015-09-28T12:21:52Z"
+		},
+		{
 			"checksumSHA1": "mGbTYZ8dHVTiPTTJu3ktp+84pPI=",
 			"path": "github.com/stretchr/testify/assert",
 			"revision": "890a5c3458b43e6104ff5da8dfa139d013d77544",
 			"revisionTime": "2017-07-05T02:17:15Z"
 		},
 		{
+			"checksumSHA1": "o+jsS/rxceTym4M3reSPfrPxaio=",
+			"path": "github.com/stretchr/testify/mock",
+			"revision": "890a5c3458b43e6104ff5da8dfa139d013d77544",
+			"revisionTime": "2017-07-05T02:17:15Z"
+		},
+		{
 			"checksumSHA1": "7vs6dSc1PPGBKyzb/SCIyeMJPLQ=",
 			"path": "github.com/stretchr/testify/require",
+			"revision": "890a5c3458b43e6104ff5da8dfa139d013d77544",
+			"revisionTime": "2017-07-05T02:17:15Z"
+		},
+		{
+			"checksumSHA1": "uefllr2OtKBGo/kQSAPbW3w6p0A=",
+			"path": "github.com/stretchr/testify/suite",
 			"revision": "890a5c3458b43e6104ff5da8dfa139d013d77544",
 			"revisionTime": "2017-07-05T02:17:15Z"
 		},


### PR DESCRIPTION
Annotations are now saved to the configured save endpoint prior to being published to UPP. Refactoring resource tests.