### PR TITLE
Add healthcheck for local annotations R/W service.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 /annotations-publisher
+/*.exe
 /vendor/*
 !/vendor/vendor.json
+
+.idea/

--- a/annotations/annotations_rw_client.go
+++ b/annotations/annotations_rw_client.go
@@ -1,0 +1,57 @@
+package annotations
+
+import (
+	"fmt"
+	"net/http"
+	"net/url"
+
+	status "github.com/Financial-Times/service-status-go/httphandlers"
+)
+
+type PublishedAnnotationsWriter interface {
+	GTG() error
+	Endpoint() string
+}
+
+type genericRWClient struct {
+	client          *http.Client
+	rwEndpoint string
+	gtgEndpoint     string
+}
+
+func NewPublishedAnnotationsWriter(endpoint string) (PublishedAnnotationsWriter, error) {
+	v, err := url.Parse(fmt.Sprintf(endpoint, "dummy"))
+	if err != nil {
+		return nil, err
+	}
+
+	gtg, _ := url.Parse(status.GTGPath)
+	gtgUrl := v.ResolveReference(gtg)
+
+	return &genericRWClient{client: &http.Client{}, rwEndpoint: endpoint, gtgEndpoint: gtgUrl.String()}, nil
+}
+
+func (rw *genericRWClient) GTG() error {
+	req, err := http.NewRequest("GET", rw.gtgEndpoint, nil)
+	if err != nil {
+		return err
+	}
+
+	req.Header.Add("User-Agent", userAgent)
+	resp, err := rw.client.Do(req)
+	if err != nil {
+		return err
+	}
+
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("GTG %v returned a %v status code", rw.gtgEndpoint, resp.StatusCode)
+	}
+
+	return nil
+}
+
+func (rw *genericRWClient) Endpoint() string {
+	return rw.rwEndpoint
+}

--- a/annotations/annotations_rw_client_test.go
+++ b/annotations/annotations_rw_client_test.go
@@ -1,0 +1,54 @@
+package annotations
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	status "github.com/Financial-Times/service-status-go/httphandlers"
+	"github.com/husobee/vestigo"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAnnotationsRWGTG(t *testing.T) {
+	server := mockGtgServer(t, true)
+	defer server.Close()
+
+	client, err := NewPublishedAnnotationsWriter(server.URL + "/%s")
+	assert.NoError(t, err)
+
+	err = client.GTG()
+	assert.NoError(t, err)
+}
+
+func TestAnnotationsRWGTGFails(t *testing.T) {
+	server := mockGtgServer(t, false)
+	defer server.Close()
+
+	client, err := NewPublishedAnnotationsWriter(server.URL + "/%s")
+	err = client.GTG()
+	assert.EqualError(t, err, fmt.Sprintf("GTG %v returned a %v status code", server.URL+"/__gtg", http.StatusServiceUnavailable))
+}
+
+func TestAnnotationsRWGTGInvalidURL(t *testing.T) {
+	client, err := NewPublishedAnnotationsWriter(":#")
+	assert.Nil(t, client, "New PublishedAnnotationsWriter should not have returned a client")
+	assert.EqualError(t, err, "parse :: missing protocol scheme")
+}
+
+func mockGtgServer(t *testing.T, gtgOk bool) *httptest.Server {
+	r := vestigo.NewRouter()
+	r.Get(status.GTGPath, func(w http.ResponseWriter, r *http.Request) {
+		userAgent := r.Header.Get("User-Agent")
+		assert.Equal(t, "PAC annotations-publisher", userAgent)
+
+		if !gtgOk {
+			w.WriteHeader(http.StatusServiceUnavailable)
+		} else {
+			w.WriteHeader(http.StatusOK)
+		}
+	})
+
+	return httptest.NewServer(r)
+}

--- a/annotations/publisher.go
+++ b/annotations/publisher.go
@@ -9,6 +9,10 @@ import (
 	"strings"
 )
 
+const (
+	userAgent = "PAC annotations-publisher"
+)
+
 // ErrInvalidAuthentication occurs when UPP responds with a 401
 var ErrInvalidAuthentication = errors.New("Publish authentication is invalid")
 
@@ -89,7 +93,7 @@ func (a *uppPublisher) GTG() error {
 		return err
 	}
 
-	req.Header.Add("User-Agent", "PAC annotations-publisher")
+	req.Header.Add("User-Agent", userAgent)
 	resp, err := a.client.Do(req)
 	if err != nil {
 		return err

--- a/api/dredd-hooks.js
+++ b/api/dredd-hooks.js
@@ -1,0 +1,8 @@
+var hooks = require('hooks');
+
+hooks.beforeEach(function (transaction) {
+    if (transaction.name.startsWith("Health > /__gtg")) {
+        hooks.log("skipping: " + transaction.name);
+        transaction.skip = true;
+    }
+});

--- a/dredd.yml
+++ b/dredd.yml
@@ -1,6 +1,5 @@
 dry-run: null
-hookfiles: null
-language: go
+hookfiles: ./api/dredd-hooks.js
 sandbox: false
 server: ./annotations-publisher
 server-wait: 3

--- a/health/healthchecks.go
+++ b/health/healthchecks.go
@@ -12,18 +12,26 @@ import (
 // HealthService runs application health checks, and provides the /__health http endpoint
 type HealthService struct {
 	fthealth.HealthCheck
+	gtgChecks []fthealth.Check
 	publisher annotations.Publisher
+	writer annotations.PublishedAnnotationsWriter
 }
 
 // NewHealthService returns a new HealthService
-func NewHealthService(appSystemCode string, appName string, appDescription string, publisher annotations.Publisher) *HealthService {
-	service := &HealthService{publisher: publisher}
+func NewHealthService(appSystemCode string, appName string, appDescription string, publisher annotations.Publisher, writer annotations.PublishedAnnotationsWriter) *HealthService {
+	service := &HealthService{publisher: publisher, writer: writer}
 	service.SystemCode = appSystemCode
 	service.Name = appName
 	service.Description = appDescription
 	service.Checks = []fthealth.Check{
+		service.writerCheck(),
 		service.publishCheck(),
 	}
+	// For GTG, only check the local writer; even if UPP is unhealthy, we should still attempt to publish, and therefore remain ready
+	service.gtgChecks = []fthealth.Check{
+		service.writerCheck(),
+	}
+
 	return service
 }
 
@@ -51,7 +59,33 @@ func (service *HealthService) publishHealthChecker() (string, error) {
 	return "UPP Publishing Pipeline is healthy", nil
 }
 
+func (service *HealthService) writerCheck() fthealth.Check {
+	return fthealth.Check{
+		ID:               "check-annotations-writer-health",
+		BusinessImpact:   "Annotations cannot be published to UPP",
+		Name:             "Check the PAC annotations R/W service",
+		PanicGuide:       "https://dewey.ft.com/annotations-publisher.html",
+		Severity:         1,
+		TechnicalSummary: fmt.Sprintf("Generic R/W service for saving published annotations is not available at %v", service.writer.Endpoint()),
+		Checker:          service.writerHealthChecker,
+	}
+}
+
+func (service *HealthService) writerHealthChecker() (string, error) {
+	if err := service.writer.GTG(); err != nil {
+		return "PAC annotations writer is not healthy", err
+	}
+	return "PAC annotations writer is healthy", nil
+}
+
 // GTG returns the current gtg status
 func (service *HealthService) GTG() gtg.Status {
-	return gtg.Status{GoodToGo: true, Message: "OK"} // even if UPP is unhealthy, we should still attempt to publish, and therefore remain ready
+	for _, check := range service.gtgChecks {
+		msg, err := check.Checker()
+		if err != nil {
+			return gtg.Status{GoodToGo: false, Message: msg}
+		}
+	}
+
+	return gtg.Status{GoodToGo: true, Message: "OK"}
 }

--- a/health/healthchecks_test.go
+++ b/health/healthchecks_test.go
@@ -9,9 +9,35 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestPublishedAnnotationsWriterCheck(t *testing.T) {
+	mockGtg := &mockPublisher{mockGtg{gtg: nil, endpoint: "/__gtg"}}
+	health := NewHealthService("appSystemCode", "appName", "appDescription", mockGtg, mockGtg)
+
+	check := health.writerCheck()
+	assert.Equal(t, "check-annotations-writer-health", check.ID)
+	assert.Equal(t, "Annotations cannot be published to UPP", check.BusinessImpact)
+	assert.Equal(t, "Check the PAC annotations R/W service", check.Name)
+	assert.Equal(t, "https://dewey.ft.com/annotations-publisher.html", check.PanicGuide)
+	assert.Equal(t, uint8(1), check.Severity)
+	assert.Equal(t, "Generic R/W service for saving published annotations is not available at /__gtg", check.TechnicalSummary)
+
+	msg, err := check.Checker()
+	assert.Equal(t, "PAC annotations writer is healthy", msg)
+	assert.NoError(t, err)
+}
+
+func TestPublishedAnnotationsWriterCheckFails(t *testing.T) {
+	mockUnhealthy := &mockGtg{gtg: errors.New("eek"), endpoint: "/__gtg"}
+	health := NewHealthService("appSystemCode", "appName", "appDescription", &mockPublisher{}, mockUnhealthy)
+
+	msg, err := health.writerCheck().Checker()
+	assert.Equal(t, "PAC annotations writer is not healthy", msg)
+	assert.EqualError(t, err, "eek")
+}
+
 func TestPublishCheck(t *testing.T) {
-	mockPublisher := &mockPublisher{gtg: nil, endpoint: "/__gtg"}
-	health := NewHealthService("appSystemCode", "appName", "appDescription", mockPublisher)
+	mockGtg := &mockPublisher{mockGtg{gtg: nil, endpoint: "/__gtg"}}
+	health := NewHealthService("appSystemCode", "appName", "appDescription", mockGtg, mockGtg)
 
 	check := health.publishCheck()
 	assert.Equal(t, "check-annotations-publish-health", check.ID)
@@ -27,8 +53,8 @@ func TestPublishCheck(t *testing.T) {
 }
 
 func TestPublishCheckFails(t *testing.T) {
-	mockPublisher := &mockPublisher{gtg: errors.New("eek"), endpoint: "/__gtg"}
-	health := NewHealthService("appSystemCode", "appName", "appDescription", mockPublisher)
+	mockPublisher := &mockPublisher{mockGtg{gtg: errors.New("eek"), endpoint: "/__gtg"}}
+	health := NewHealthService("appSystemCode", "appName", "appDescription", mockPublisher, &mockGtg{})
 
 	msg, err := health.publishCheck().Checker()
 	assert.Equal(t, "UPP Publishing Pipeline is not healthy", msg)
@@ -36,8 +62,8 @@ func TestPublishCheckFails(t *testing.T) {
 }
 
 func TestHealthServiceHandler(t *testing.T) {
-	mockPublisher := &mockPublisher{gtg: nil, endpoint: "/__gtg"}
-	health := NewHealthService("appSystemCode", "appName", "appDescription", mockPublisher)
+	mockGtg := &mockPublisher{mockGtg{gtg: nil, endpoint: "/__gtg"}}
+	health := NewHealthService("appSystemCode", "appName", "appDescription", mockGtg, mockGtg)
 
 	handler := health.HealthCheckHandleFunc()
 	w := httptest.NewRecorder()
@@ -49,28 +75,50 @@ func TestHealthServiceHandler(t *testing.T) {
 	assert.NotEmpty(t, w.Body)
 }
 
-func TestGTG(t *testing.T) {
-	mockPublisher := &mockPublisher{gtg: errors.New("eek"), endpoint: "/__gtg"}
-	health := NewHealthService("appSystemCode", "appName", "appDescription", mockPublisher)
+func TestGTGAllGood(t *testing.T) {
+	health := NewHealthService("appSystemCode", "appName", "appDescription", &mockPublisher{}, &mockGtg{})
 
 	gtg := health.GTG()
 	assert.True(t, gtg.GoodToGo)
 	assert.Equal(t, "OK", gtg.Message)
 }
 
-type mockPublisher struct {
+func TestGTGEvenThoughUPPIsUnhealthy(t *testing.T) {
+	mockPublisher := &mockPublisher{mockGtg{gtg: errors.New("eek"), endpoint: "/__gtg"}}
+	health := NewHealthService("appSystemCode", "appName", "appDescription", mockPublisher, &mockGtg{})
+
+	gtg := health.GTG()
+	assert.True(t, gtg.GoodToGo)
+	assert.Equal(t, "OK", gtg.Message)
+}
+
+func TestGTGFailsWhenWriterIsUnhealthy(t *testing.T) {
+	mockPublisher := &mockPublisher{}
+	mockUnhealthy := &mockGtg{gtg: errors.New("eek"), endpoint: "/__gtg"}
+	health := NewHealthService("appSystemCode", "appName", "appDescription", mockPublisher, mockUnhealthy)
+
+	gtg := health.GTG()
+	assert.False(t, gtg.GoodToGo)
+	assert.Equal(t, "PAC annotations writer is not healthy", gtg.Message)
+}
+
+type mockGtg struct {
 	gtg      error
 	endpoint string
 }
 
-func (m *mockPublisher) GTG() error {
+func (m *mockGtg) GTG() error {
 	return m.gtg
+}
+
+func (m *mockGtg) Endpoint() string {
+	return m.endpoint
+}
+
+type mockPublisher struct {
+	mockGtg
 }
 
 func (m *mockPublisher) Publish(uuid string, tid string, body map[string]interface{}) error {
 	return nil
-}
-
-func (m *mockPublisher) Endpoint() string {
-	return m.endpoint
 }


### PR DESCRIPTION
A healthy generic-rw-aurora service is required for saving published annotations, so this check is also incorporated into GTG requests.