### PR TITLE
Duplicate host names

### DIFF
--- a/helm/annotations-publisher/templates/admin-ingress.yaml
+++ b/helm/annotations-publisher/templates/admin-ingress.yaml
@@ -19,3 +19,10 @@ spec:
           backend:
             serviceName: {{.Values.service.name}}
             servicePort: 8080
+    - host: "*.upp.ft.com"
+      http:
+        paths:
+        - path: /__{{.Values.service.name}}/
+          backend:
+            serviceName: {{.Values.service.name}}
+            servicePort: 8080

--- a/helm/annotations-publisher/templates/ingress.yaml
+++ b/helm/annotations-publisher/templates/ingress.yaml
@@ -19,3 +19,10 @@ spec:
           backend:
             serviceName: {{.Values.service.name}}
             servicePort: 8080
+    - host: "*.upp.ft.com"
+      http:
+        paths:
+        - path: /drafts/content/.*/annotations/publish
+          backend:
+            serviceName: {{.Values.service.name}}
+            servicePort: 8080


### PR DESCRIPTION
Due to a migration to new subdomain the host as duplicated in order to support two host until the migration is completed.