### PR TITLE
Automatically recreating RUNBOOK.md without relationships [Skip CI]

### DIFF
--- a/runbooks/runbook.md
+++ b/runbooks/runbook.md
@@ -1,100 +1,128 @@
+<!--
+    Written in the format prescribed by https://github.com/Financial-Times/runbook.md.
+    Any future edits should abide by this format.
+-->
 # PAC Annotations Publisher
 
 Annotations Publisher is a micro-service that Publishes annotations from TagMe to UPP.
 
 ## Code
+
 annotations-publisher
 
 ## Primary URL
+
 https://pac-prod-glb.upp.ft.com/__annotations-publisher
 
 ## Service Tier
+
 Platinum
 
 ## Lifecycle Stage
+
 Production
 
-## Delivered By
-content
-
-## Supported By
-content
-
-## Known About By
-
-- elitsa.pavlova
-- kalin.arsov
-- marina.chompalova
-- miroslav.gatsanoga
-- ivan.nikolov
-- donislav.belev
-- mihail.mihaylov
-- boyko.boykov
-
 ## Host Platform
+
 AWS
 
 ## Architecture
+
 Annotations Publisher is part of the PAC clusters, it is deployed in both EU and US regions with two replicas per deployment. The service is used to publish draft annotations to UPP.
 
 [PAC architecture diagram](https://app.lucidchart.com/publicSegments/view/22c1656b-6242-4da6-9dfb-f7225c20f38f/image.png)
 
 ## Contains Personal Data
+
 No
 
 ## Contains Sensitive Data
+
 No
 
-## Dependencies
-- cms-metadata-notifier
-- generic-rw-aurora
-- draft-annotations-api
+<!-- Placeholder - remove HTML comment markers to activate
+## Can Download Personal Data
+Choose Yes or No
+
+...or delete this placeholder if not applicable to this system
+-->
+
+<!-- Placeholder - remove HTML comment markers to activate
+## Can Contact Individuals
+Choose Yes or No
+
+...or delete this placeholder if not applicable to this system
+-->
 
 ## Failover Architecture Type
+
 ActiveActive
 
 ## Failover Process Type
+
 FullyAutomated
 
 ## Failback Process Type
+
 FullyAutomated
 
 ## Failover Details
+
 The service is deployed in both PAC clusters. The failover guide for the cluster is located [here](https://github.com/Financial-Times/upp-docs/tree/master/failover-guides/pac-cluster).
 
 ## Data Recovery Process Type
+
 NotApplicable
 
 ## Data Recovery Details
+
 The service does not store data, so it does not require any data recovery steps.
 
 ## Release Process Type
+
 PartiallyAutomated
 
 ## Rollback Process Type
+
 Manual
 
 ## Release Details
+
 Manual failover is needed when a new version of the service is deployed to production. Otherwise, an automated failover is going to take place when releasing.
 For more details about the failover process see the [PAC failover guide](https://github.com/Financial-Times/upp-docs/tree/master/failover-guides/pac-cluster).
 
+<!-- Placeholder - remove HTML comment markers to activate
+## Heroku Pipeline Name
+Enter descriptive text satisfying the following:
+This is the name of the Heroku pipeline for this system. If you don't have a pipeline, this is the name of the app in Heroku. A pipeline is a group of Heroku apps that share the same codebase where each app in a pipeline represents the different stages in a continuous delivery workflow, i.e. staging, production.
+
+...or delete this placeholder if not applicable to this system
+-->
+
 ## Key Management Process Type
+
 Manual
 
 ## Key Management Details
+
 The service uses sealed secrets to manage Kubernetes secrets.
 The actions required to create/change sealed secrets are described [here](https://github.com/Financial-Times/upp-docs/tree/master/guides/sealed-secrets-guide/).
 
 ## Monitoring
+
 Health Checks:
-- [PAC Prod EU](https://pac-prod-eu.upp.ft.com/__health/__pods-health?service-name=annotations-publisher)
-- [PAC Prod US](https://pac-prod-us.upp.ft.com/__health/__pods-health?service-name=annotations-publisher)
+
+*   [PAC Prod EU](https://pac-prod-eu.upp.ft.com/__health/__pods-health?service-name=annotations-publisher)
+*   [PAC Prod US](https://pac-prod-us.upp.ft.com/__health/__pods-health?service-name=annotations-publisher)
 
 Splunk Alerts:
-- [PAC Annotations Publish Failures](https://financialtimes.splunkcloud.com/en-US/app/financial_times_production/alert?s=%2FservicesNS%2Fnobody%2Ffinancial_times_production%2Fsaved%2Fsearches%2FPAC%2520Annotations%2520Failures)
+
+*   [PAC Annotations Publish Failures](https://financialtimes.splunkcloud.com/en-US/app/financial_times_production/alert?s=%2FservicesNS%2Fnobody%2Ffinancial_times_production%2Fsaved%2Fsearches%2FPAC%2520Annotations%2520Failures)
 
 ## First Line Troubleshooting
+
 Please refer to the [First Line Troubleshooting guide](https://github.com/Financial-Times/upp-docs/tree/master/guides/ops/first-line-troubleshooting).
 
 ## Second Line Troubleshooting
+
 Please refer to the GitHub repository README for troubleshooting information.


### PR DESCRIPTION

## What
 - The [RUNBOOK.md](https://github.com/Financial-Times/annotations-publisher/blob/runbook-no-relationships-2021-03-19/runbooks/runbook.md) file has been automatically regenerated from the Biz Ops data for the **annotations-publisher** system.
 - All the relationships/dependencies have been excluded from RUNBOOK.md but are still in the **annotations-publisher** system in [Biz Ops](https://biz-ops.in.ft.com/System/annotations-publisher).
 - Please continue to manage those relationships/dependencies manually or via the Biz Ops API.

## Why
 - Support for relationships/dependencies within RUNBOOK.md is being removed to avoid the side effects [identified in this proposal](https://docs.google.com/document/d/1njFceyb49TeaIR53Y9r62CenTzdey1fyeJkUvxd9SQQ)
 - This is a prerequisite to the improved ownership/support model [defined in this proposal](https://docs.google.com/document/d/1vTRe7S5dUqIMAoWyqD2pMEkg_5998NCEeFwsxT_k9pw).

## Next Steps
 - Please check and merge this PR.
 - You should only see the removal of the **Delivered By**, **Supported By**, **Technical Owner**, **Known About By**, **Stakeholders**, **Dependencies** and **Healthcheck** sections. Please contact [#reliability-eng](https://financialtimes.slack.com/archives/C07B3043U) if there are other differences as your current runbook.md file may be inconsistent with Biz Ops.
 - [Reliability Engineering](https://financialtimes.slack.com/archives/C07B3043U) are unlocking all the relationships/dependencies to re-enable manual/API updates.
 - [Reliability Engineering](https://financialtimes.slack.com/archives/C07B3043U) are adjusting the rules to allow these simpler RUNBOOK.md files to pass validation.
